### PR TITLE
new: adapt to new contract with dades jardiner for plants

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Switch production data sources from plantmonitor (erp) to jardiner (dset)
+- Update expected back2back data for plantProductionSeries and plantPowerSeries
 - Bump Babel dependency
 - Upgrade Notes:
     - Reinstall python dependencies

--- a/b2bdata/som_opendata.queries_test.Queries_Test.test_plantPowerSeries_many-expected
+++ b/b2bdata/som_opendata.queries_test.Queries_Test.test_plantPowerSeries_many-expected
@@ -3,12 +3,13 @@ ES	España	01	Andalucia	04	Almería	04090	Tahal	0	0
 ES	España	01	Andalucia	18	Granada	18152	Pedro Martínez	0	0
 ES	España	01	Andalucia	41	Sevilla	41006	Alcolea del Río	0	1890
 ES	España	01	Andalucia	41	Sevilla	41055	Lora del Río	0	3400
-ES	España	07	Castilla y León	47	Valladolid	47114	Peñafiel	0	1000
 ES	España	07	Castilla y León	05	Ávila	05074	Fontiveros	0	800
+ES	España	07	Castilla y León	47	Valladolid	47114	Peñafiel	0	1000
 ES	España	09	Cataluña	08	Barcelona	08112	Manlleu	190	190
+ES	España	09	Cataluña	08	Barcelona	08301	Mataró	0	0
 ES	España	09	Cataluña	17	Girona	17148	Riudarenes	58	58
 ES	España	09	Cataluña	25	Lleida	25120	Lleida	99	99
 ES	España	09	Cataluña	25	Lleida	25228	Torrefarrera	90	90
-ES	España	09	Cataluña	25	Lleida	25230	Torregrossa	0	499
+ES	España	09	Cataluña	25	Lleida	25230	Torregrossa	499	499
 ES	España	10	Comunidad Valenciana	46	Valencia/València	46193	Picanya	290	290
-ES	Spain	30	Murcia	14	Región de Murcia	30395	Cartagena	0	0
+ES	España	14	Murcia	30	Murcia	30016	Cartagena	0	0

--- a/b2bdata/som_opendata.queries_test.Queries_Test.test_plantProductionSeries_many-expected
+++ b/b2bdata/som_opendata.queries_test.Queries_Test.test_plantProductionSeries_many-expected
@@ -1,14 +1,15 @@
 codi_pais	pais	codi_ccaa	comunitat_autonoma	codi_provincia	provincia	codi_ine	municipi	count_2015_01_01	count_2020_10_01
 ES	España	01	Andalucia	04	Almería	04090	Tahal	0	0
 ES	España	01	Andalucia	18	Granada	18152	Pedro Martínez	0	0
-ES	España	01	Andalucia	41	Sevilla	41006	Alcolea del Río	0	283440
-ES	España	01	Andalucia	41	Sevilla	41055	Lora del Río	0	574468
-ES	España	07	Castilla y León	47	Valladolid	47114	Peñafiel	0	61630
-ES	España	07	Castilla y León	05	Ávila	05074	Fontiveros	0	94100
-ES	España	09	Cataluña	08	Barcelona	08112	Manlleu	9884	17589
-ES	España	09	Cataluña	17	Girona	17148	Riudarenes	3845	5723
-ES	España	09	Cataluña	25	Lleida	25120	Lleida	4944	12615
-ES	España	09	Cataluña	25	Lleida	25228	Torrefarrera	6546	13778
-ES	España	09	Cataluña	25	Lleida	25230	Torregrossa	147000	191000
-ES	España	10	Comunidad Valenciana	46	Valencia/València	46193	Picanya	18067	35274
-ES	Spain	30	Murcia	14	Región de Murcia	30395	Cartagena	0	0
+ES	España	01	Andalucia	41	Sevilla	41006	Alcolea del Río	0	283443
+ES	España	01	Andalucia	41	Sevilla	41055	Lora del Río	0	238049
+ES	España	07	Castilla y León	05	Ávila	05074	Fontiveros	0	94112
+ES	España	07	Castilla y León	47	Valladolid	47114	Peñafiel	0	61601
+ES	España	09	Cataluña	08	Barcelona	08112	Manlleu	0	17589
+ES	España	09	Cataluña	08	Barcelona	08301	Mataró	0	0
+ES	España	09	Cataluña	17	Girona	17148	Riudarenes	0	5723
+ES	España	09	Cataluña	25	Lleida	25120	Lleida	0	12615
+ES	España	09	Cataluña	25	Lleida	25228	Torrefarrera	0	13778
+ES	España	09	Cataluña	25	Lleida	25230	Torregrossa	0	191002
+ES	España	10	Comunidad Valenciana	46	Valencia/València	46193	Picanya	0	35274
+ES	España	14	Murcia	30	Murcia	30016	Cartagena	0	0

--- a/som_opendata/queries/plantpower.sql
+++ b/som_opendata/queries/plantpower.sql
@@ -23,8 +23,6 @@ FROM (
 		end_date as last_date
 	FROM dbt_prod.dm_plants__opendata
 ) AS item
-LEFT JOIN municipality AS city
-ON item.city_id = city.id
 GROUP BY
 	codi_pais,
 	codi_ccaa,

--- a/som_opendata/queries/plantpower.sql
+++ b/som_opendata/queries/plantpower.sql
@@ -1,23 +1,27 @@
 SELECT
-	city.countrycode AS codi_pais,
-	city.country AS pais,
-	city.regioncode AS codi_ccaa,
-	city.region AS comunitat_autonoma,
-	city.provincecode AS codi_provincia,
-	city.province AS provincia,
-	city.inecode AS codi_ine,
-	city.name AS municipi,
+	codi_pais,
+	pais,
+	codi_ccaa,
+	comunitat_autonoma,
+	codi_provincia,
+	provincia,
+	codi_ine,
+	municipi,
 	{} -- here go the count columns
 FROM (
 	SELECT
-		params.nominal_power_w / 1000 as value,
-		params.connection_date as first_date,
-		null::date as last_date,
-		plant.municipality as city_id
-	FROM plant
-	LEFT JOIN plantparameters AS params
-	ON params.plant = plant.id
-	WHERE plant.description != 'SomRenovables'
+		codi_pais,
+		pais,
+		codi_ccaa,
+		comunitat_autonoma,
+		codi_provincia,
+		provincia,
+		codi_ine,
+		municipi,
+		plant_nominal_power_kw as value,
+		connection_date as first_date,
+		end_date as last_date
+	FROM dbt_prod.dm_plants__opendata
 ) AS item
 LEFT JOIN municipality AS city
 ON item.city_id = city.id

--- a/som_opendata/queries/plantproduction.sql
+++ b/som_opendata/queries/plantproduction.sql
@@ -1,25 +1,27 @@
 SELECT
-	city.countrycode AS codi_pais,
-	city.country AS pais,
-	city.regioncode AS codi_ccaa,
-	city.region AS comunitat_autonoma,
-	city.provincecode AS codi_provincia,
-	city.province AS provincia,
-	city.inecode AS codi_ine,
-	city.name AS municipi,
+	codi_pais,
+	pais,
+	codi_ccaa,
+	comunitat_autonoma,
+	codi_provincia,
+	provincia,
+	codi_ine,
+	municipi,
 	{} -- here go the count columns
 FROM (
 	SELECT
-		plant.municipality as city_id,
-		energy.export_energy_wh/1000 as value,
-		energy.time as time
-	FROM prod.view_plant_export_energy_monthly AS energy
-	LEFT JOIN plant
-	ON energy.plant_id = plant.id
-	WHERE plant.description != 'SomRenovables'
+		codi_pais,
+		pais,
+		codi_ccaa,
+		comunitat_autonoma,
+		codi_provincia,
+		provincia,
+		codi_ine,
+		municipi,
+		energia_exportada_kwh as value,
+		month as time
+	FROM dbt_prod.dm_plant_production_monthly__opendata
 ) AS item
-LEFT JOIN municipality AS city
-ON item.city_id = city.id
 GROUP BY
 	codi_pais,
 	codi_ccaa,


### PR DESCRIPTION
## Description

[FreeScout incidence](https://github.com/Som-Energia/somenergia-opendata/pull/10)

opendata will start using the jardiner pipe data for plants based on dset (and monitored by Gestió d'Actius) instead of the legacy dades pipe based on erp, which are not supervised by GA anymore.

## Changes

- Made plantpower.sql and plantproduction.sql point to a dades datamart.

Note: on the otherside we've made [a contract](https://gitlab.somenergia.coop/et/somenergia-jardiner/-/merge_requests/147/diffs#4fe8f6f16ef3dc2a26171f4843760bd2c7dc2f91_155_159) regarding the shape of that table

## Checklist

Justify any unchecked point:

- [x] Changed code is covered by tests.
- [X] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [x] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## Observations

we've deployed to production and the application is responding correctly
